### PR TITLE
Cleanup for DataFrames 0.19.4, fixing issue with countries with no data

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,9 +192,9 @@ julia> search_wdi("indicators","name",r"gross national expenditure"i)
 ...
 julia> search_wdi("indicators","description",r"gross national expenditure"i)
 ...
-julia> search_wdi("indicators","source_database",r"Sustainable"i)
+julia> search_wdi("indicators", "source_database", r"Sustainable"i)
 ...
-julia> search_wdi("indicators","source_organization",r"Global Partnership"i)
+julia> search_wdi("indicators", "source_organization", r"Global Partnership"i)
 
 ```
 
@@ -203,8 +203,8 @@ julia> search_wdi("indicators","source_organization",r"Global Partnership"i)
 ### Extracting country data from results
 
 ```julia
-df=wdi("NY.GNP.PCAP.CD", ["US","BR"], 1980, 2012, extra=true)
-us_gnp=df[df[:iso2c] .== "US",:]
+df = wdi("NY.GNP.PCAP.CD", ["US","BR"]; startyear = 1980, endyear = 2012, extra = true)
+us_gnp = df[df.iso2c .== "US", :]
 ```
 
 ### Year format
@@ -218,8 +218,8 @@ You can easily convert this to a Date series:
 using WorldBankData
 using Dates
 
-df=wdi("AG.LND.ARBL.HA.PC", "US", 1900, 2011)
-df[:year] = map(Date, df[:year])
+df = wdi("AG.LND.ARBL.HA.PC", "US", startyear = 1900, endyear = 2011)
+df.year = Date.(df.year)
 ```
 
 ### Plotting
@@ -231,27 +231,9 @@ Install the [Plots.jl](https://github.com/JuliaPlots/Plots.jl) package with
 using WorldBankData
 using Plots
 
-df=wdi("AG.LND.ARBL.HA.PC", "US", 1980, 2010)
+df = wdi("AG.LND.ARBL.HA.PC", "US"; startyear = 1980, endyear = 2010)
 
-plot(df[:year], df[:AG_LND_ARBL_HA_PC])
-```
-
-### Empty/Missing results
-
-`wdi` will return an empty DataFrame without warning if there is no data:
-```julia
-julia> dfAS=wdi("EN.ATM.CO2E.KT", "AS")
-0x4 DataFrame
-```
-
-You can check for this with `size(dfAS)[1]==0`.
-
-It will return a DataFrame for the cases where it has data, i.e.
-
-```julia
-julia> df=wdi("EN.ATM.CO2E.KT", ["AS","US"])
-51x4 DataFrame
-...
+plot(df.year, df.AG_LND_ARBL_HA_PC)
 ```
 
 ### Cache
@@ -307,7 +289,8 @@ function update_us_gnp_per_cap()
     df = wdi("NY.GNP.PCAP.CD", "US")
     CSV.write("us_gnp.csv",df)
 end
-df=CSV.read("us_gnp.csv")
+
+df = CSV.read("us_gnp.csv")
 ```
 one then runs the `update_us_gnp_per_cap()` function only when needed.
 

--- a/src/WorldBankData.jl
+++ b/src/WorldBankData.jl
@@ -129,13 +129,9 @@ end
 make_symbol(x::String) =  Symbol(replace(x, "." => "_"))
 
 # return boolean array of matching entries
-<<<<<<< HEAD
 regex_match(df::Array{String,1}, regex::Regex)::Array{Bool, 1} = map(x -> occursin(regex, x), df)
 
 df_match(df::AbstractDataFrame, entry::String, regex::Regex) = df[regex_match(df[!, make_symbol(entry)], regex),:]
-=======
-regex_match(df::Array{String,1}, regex::Regex) = map(x -> occursin(regex, x), df)
->>>>>>> 5f8ed7b3b8edbbde1b5b9535a41fe10bdafd5360
 
 function df_match(df::AbstractDataFrame, entry::String, regex::Regex)
     return df[regex_match(df[!, make_symbol(entry)], regex), :]
@@ -236,17 +232,12 @@ function wdi_download(indicator::String,
     if typeof(country) == String
         url = string("http://api.worldbank.org/countries/", country, "/indicators/", indicator,
                   "?date=", startyear,":", endyear, "&per_page=25000", "&format=json")
-<<<<<<< HEAD
         json_data = download_parse_json(url, verbose=verbose)[2]
-=======
-        json_data = [download_parse_json(url, verbose=verbose)[2]]
->>>>>>> 5f8ed7b3b8edbbde1b5b9535a41fe10bdafd5360
     elseif typeof(country) == Array{String,1}
         json_data = Any[]
         for c in country
 
             url = string("http://api.worldbank.org/countries/", c, "/indicators/", indicator,
-<<<<<<< HEAD
                          "?date=", startyear,":", endyear, "&per_page=25000", "&format=json")
 
             data_now = download_parse_json(url, verbose = verbose)
@@ -261,18 +252,6 @@ function wdi_download(indicator::String,
                 else
                     append!(json_data, data_now)
                 end
-=======
-                "?date=", startyear,":", endyear, "&per_page=25000", "&format=json"
-            )
-
-            data_now = [download_parse_json(url, verbose = verbose)[2]; ]
-
-            if typeof(data_now) == Vector{Nothing}
-                verbose && println("No data found for country ",c)
-                nothing
-            else
-                append!(json_data, data_now)
->>>>>>> 5f8ed7b3b8edbbde1b5b9535a41fe10bdafd5360
             end
         end
     end
@@ -325,18 +304,8 @@ df = wdi("NY.GNP.PCAP.CD", ["US","BR"], 1980, 2012, extra=true)
 df = wdi(["NY.GNP.PCAP.CD", "AG.LND.ARBL.HA.PC"], ["US","BR"], 1980, 2012, extra=true)
 ```
 """
-<<<<<<< HEAD
 function wdi(indicators::Union{String,Array{String,1}}, countries::Union{String,Array{String,1}};
      startyear::Integer=1800, endyear::Integer=3000, extra::Bool=false, verbose::Bool=false)::DataFrame
-=======
-
-function wdi(indicators::Union{String,Array{String,1}}, countries::Union{String,Array{String,1}};
-            startyear::Integer = 1800,
-            endyear::Integer = 3000,
-            extra::Bool = false,
-            verbose::Bool = false)
-
->>>>>>> 5f8ed7b3b8edbbde1b5b9535a41fe10bdafd5360
     if countries == "all"
         countries = all_countries
     end

--- a/src/WorldBankData.jl
+++ b/src/WorldBankData.jl
@@ -205,14 +205,19 @@ function search_wdi(data::String, entry::String, regx::Regex)::DataFrame
     end
 end
 
-# Function to replace Nothing type with "NA" string
-clean_entry(x::Union{AbstractString, Nothing}) = typeof(x) == Nothing ? "NA" : x
+function clean_entry(x::Union{AbstractString, Nothing})
+    if typeof(x) == Nothing
+        return "NA"
+    else
+        return x
+    end
+end
 
 function clean_append!(vals::Union{Array{String,1},Array{String,1}}, val::Union{String,String, Nothing})
     append!(vals,[clean_entry(val)])
 end
 
-function parse_wdi(indicator::String, json::Array{Any,1}, startyear::Integer, endyear::Integer)
+function parse_wdi(indicator::String, json::Array{Any,1}, startyear::Integer, endyear::Integer)::DataFrame
     country_id = String[]
     country_name = String[]
     value = String[]

--- a/src/WorldBankData.jl
+++ b/src/WorldBankData.jl
@@ -225,8 +225,8 @@ function parse_wdi(indicator::String, json::Array{Any,1}, startyear::Integer, en
         clean_append!(date,d["date"])
     end
 
-    value = tofloat.(value)
-    date = tofloat.(date)
+    value = convert_a2f(value)
+    date = convert_a2f(date)
 
     df = DataFrame(iso2c = country_id, country = country_name)
     df[!, make_symbol(indicator)] = value
@@ -274,7 +274,6 @@ function wdi_download(indicator::String,
 end
 
 all_countries = ["AW", "AF", "A9", "AO", "AL", "AD", "L5", "1A", "AE", "AR", "AM", "AS", "AG", "AU", "AT", "AZ", "BI", "B4", "B7", "BE", "BJ", "BF", "BD", "BG", "B1", "BH", "BS", "BA", "B2", "BY", "BZ", "B3", "BM", "BO", "BR", "BB", "BN", "B6", "BT", "BW", "C9", "CF", "CA", "C4", "B8", "C5", "CH", "JG", "CL", "CN", "CI", "C6", "C7", "CM", "CD", "CG", "CO", "KM", "CV", "CR", "C8", "S3", "CU", "CW", "KY", "CY", "CZ", "D4", "D7", "DE", "D8", "DJ", "D2", "DM", "D3", "D9", "DK", "N6", "DO", "D5", "F6", "D6", "6D", "DZ", "4E", "V2", "Z4", "7E", "Z7", "EC", "EG", "XC", "ER", "ES", "EE", "ET", "EU", "F1", "FI", "FJ", "FR", "FO", "FM", "6F", "GA", "GB", "GE", "GH", "GI", "GN", "GM", "GW", "GQ", "GR", "GD", "GL", "GT", "GU", "GY", "XD", "HK", "HN", "XE", "HR", "HT", "HU", "ZB", "XF", "ZT", "XG", "XH", "ID", "XI", "IM", "IN", "XY", "IE", "IR", "IQ", "IS", "IL", "IT", "JM", "JO", "JP", "KZ", "KE", "KG", "KH", "KI", "KN", "KR", "KW", "XJ", "LA", "LB", "LR", "LY", "LC", "ZJ", "L4", "XL", "XM", "LI", "LK", "XN", "XO", "LS", "V3", "LT", "LU", "LV", "MO", "MF", "MA", "L6", "MC", "MD", "M1", "MG", "MV", "ZQ", "MX", "MH", "XP", "MK", "ML", "MT", "MM", "XQ", "ME", "MN", "MP", "MZ", "MR", "MU", "MW", "MY", "XU", "M2", "NA", "NC", "NE", "NG", "NI", "NL", "6L", "NO", "NP", "6X", "NR", "6N", "NZ", "OE", "OM", "S4", "PK", "PA", "PE", "PH", "PW", "PG", "PL", "V1", "PR", "KP", "PT", "PY", "PS", "S2", "V4", "PF", "QA", "RO", "R6", "O6", "RU", "RW", "8S", "SA", "L7", "SD", "SN", "SG", "SB", "SL", "SV", "SM", "SO", "RS", "ZF", "SS", "ZG", "S1", "ST", "SR", "SK", "SI", "SE", "SZ", "SX", "A4", "SC", "SY", "TC", "TD", "T4", "T7", "TG", "TH", "TJ", "TM", "T2", "TL", "T3", "TO", "T5", "T6", "TT", "TN", "TR", "TV", "TW", "TZ", "UG", "UA", "XT", "UY", "US", "UZ", "VC", "VE", "VG", "VI", "VN", "VU", "1W", "WS", "XK", "A5", "YE", "ZA", "ZM", "ZW"]
-
 
 """
 wdi(indicators::Union{String,Array{String,1}}, countries::Union{String,Array{String,1}}, startyear::Integer=1800, endyear::Integer=3000; extra::Bool=false, verbose::Bool=false)::DataFrame

--- a/src/WorldBankData.jl
+++ b/src/WorldBankData.jl
@@ -145,7 +145,7 @@ end
 # return boolean array of matching entries
 regex_match(df::Array{String,1}, regex::Regex)::Array{Bool, 1} = map(x -> occursin(regex, x), df)
 
-df_match(df::AbstractDataFrame, entry::String, regex::Regex)::DataFrame = df[regex_match(df[make_symbol(entry)], regex),:]
+df_match(df::AbstractDataFrame, entry::String, regex::Regex)::DataFrame = df[regex_match(df[!, make_symbol(entry)], regex),:]
 
 function country_match(entry::String,regex::Regex)::DataFrame
     df = get_countries()

--- a/src/WorldBankData.jl
+++ b/src/WorldBankData.jl
@@ -308,17 +308,17 @@ function wdi(indicators::Union{String,Array{String,1}}, countries::Union{String,
     end
 
     for c in countries
-        if !(c in all_countries)
+        if ! (c in all_countries)
             error("country ",c," not found")
         end
     end
 
-    if !(startyear < endyear)
+    if ! (startyear < endyear)
         error("startyear has to be < endyear. startyear=",startyear,". endyear=",endyear)
     end
 
     if typeof(indicators) == String
-        indicators = [indicators]
+        indicators=[indicators]
     end
 
     df = wdi_download(indicators[1], countries, startyear, endyear, verbose=verbose)
@@ -326,21 +326,19 @@ function wdi(indicators::Union{String,Array{String,1}}, countries::Union{String,
     if length(indicators) > 1
         for ind in indicators[2:length(indicators)]
             dfn = wdi_download(ind, countries, startyear, endyear, verbose=verbose)
-            df = join(df, dfn,
-                on = [x for x in filter(x -> !(x in map(make_symbol, indicators)), names(df))],
-                kind = :outer
-            )
+            df = join(df, dfn, on = [x for x in filter(x -> !(x in map(make_symbol, indicators)), names(df))],
+                               kind = :outer)
         end
     end
 
     if extra
-        cntdat = get_countries(verbose = verbose)
-        df = join(df, cntdat, on=:iso2c)
+        cntdat = get_countries(verbose=verbose)
+        df = join(df,cntdat,on=:iso2c)
     end
 
     sort!(df, [order(:iso2c), order(:year)])
 
-    return df
+    df
 end
 
 end

--- a/test/countries.jl
+++ b/test/countries.jl
@@ -4,14 +4,14 @@ using Test
 using WorldBankData
 
 
-country_data = Any[ Dict("total"=>4,"per_page"=>"25000","pages"=>1,"page"=>1),
-                 Any[
-                    Dict("latitude"=>"42.5075","id"=>"AND","iso2Code"=>"AD","incomeLevel"=>Dict("id"=>"NOC","value"=>"High income: nonOECD"),"adminregion"=>Dict("id"=>"","value"=>""),"lendingType"=>Dict("id"=>"LNX","value"=>"Not classified"),"region"=>Dict("id"=>"ECS","value"=>"Europe & Central Asia (all income levels)"),"capitalCity"=>"Andorra la Vella","name"=>"Andorra","longitude"=>"1.5218"),
-                    Dict("latitude"=>"","id"=>"ARB","iso2Code"=>"1A","incomeLevel"=>Dict("id"=>"NA","value"=>"Aggregates"),"adminregion"=>Dict("id"=>"","value"=>""),"lendingType"=>Dict("id"=>"","value"=>"Aggregates"),"region"=>Dict("id"=>"NA","value"=>"Aggregates"),"capitalCity"=>"","name"=>"Arab World","longitude"=>""),
-                    Dict("latitude"=>"24.4764","id"=>"ARE","iso2Code"=>"AE","incomeLevel"=>Dict("id"=>"NOC","value"=>"High income: nonOECD"),"adminregion"=>Dict("id"=>"","value"=>""),"lendingType"=>Dict("id"=>"LNX","value"=>"Not classified"),"region"=>Dict("id"=>"MEA","value"=>"Middle East & North Africa (all income levels)"),"capitalCity"=>"Abu Dhabi","name"=>"United Arab Emirates","longitude"=>"54.3705"),
-                    Dict("latitude"=>"-34.6118","id"=>"ARG","iso2Code"=>"AR","incomeLevel"=>Dict("id"=>"UMC","value"=>"Upper middle income"),"adminregion"=>Dict("id"=>"LAC","value"=>"Latin America & Caribbean (developing only)"),"lendingType"=>Dict("id"=>"IBD","value"=>"IBRD"),"region"=>Dict("id"=>"LCN","value"=>"Latin America & Caribbean (all income levels)"),"capitalCity"=>"Buenos Aires","name"=>"Argentina","longitude"=>"-58.4173"),
-                 ]
-               ]
+country_data = Any[
+  Dict("total" => 4, "per_page" => "25000", "pages" => 1, "page" = >1),
+    Any[Dict("latitude"=>"42.5075","id"=>"AND","iso2Code"=>"AD","incomeLevel"=>Dict("id"=>"NOC","value"=>"High income: nonOECD"),"adminregion"=>Dict("id"=>"","value"=>""),"lendingType"=>Dict("id"=>"LNX","value"=>"Not classified"),"region"=>Dict("id"=>"ECS","value"=>"Europe & Central Asia (all income levels)"),"capitalCity"=>"Andorra la Vella","name"=>"Andorra","longitude"=>"1.5218"),
+        Dict("latitude"=>"","id"=>"ARB","iso2Code"=>"1A","incomeLevel"=>Dict("id"=>"NA","value"=>"Aggregates"),"adminregion"=>Dict("id"=>"","value"=>""),"lendingType"=>Dict("id"=>"","value"=>"Aggregates"),"region"=>Dict("id"=>"NA","value"=>"Aggregates"),"capitalCity"=>"","name"=>"Arab World","longitude"=>""),
+        Dict("latitude"=>"24.4764","id"=>"ARE","iso2Code"=>"AE","incomeLevel"=>Dict("id"=>"NOC","value"=>"High income: nonOECD"),"adminregion"=>Dict("id"=>"","value"=>""),"lendingType"=>Dict("id"=>"LNX","value"=>"Not classified"),"region"=>Dict("id"=>"MEA","value"=>"Middle East & North Africa (all income levels)"),"capitalCity"=>"Abu Dhabi","name"=>"United Arab Emirates","longitude"=>"54.3705"),
+        Dict("latitude"=>"-34.6118","id"=>"ARG","iso2Code"=>"AR","incomeLevel"=>Dict("id"=>"UMC","value"=>"Upper middle income"),"adminregion"=>Dict("id"=>"LAC","value"=>"Latin America & Caribbean (developing only)"),"lendingType"=>Dict("id"=>"IBD","value"=>"IBRD"),"region"=>Dict("id"=>"LCN","value"=>"Latin America & Caribbean (all income levels)"),"capitalCity"=>"Buenos Aires","name"=>"Argentina","longitude"=>"-58.4173"),
+    ]
+]
 
 df_country = WorldBankData.parse_country(country_data)
 

--- a/test/example_dl.jl
+++ b/test/example_dl.jl
@@ -23,7 +23,8 @@ end
 function try_download(cntr=5)
     dfweb = ""
     while cntr > 0
-        dfweb = wdi(["NY.GNP.PCAP.CD", "AG.LND.ARBL.HA.PC"], ["US", "BR"], 1980, 2008, extra=true, verbose=true)
+        dfweb = wdi(["NY.GNP.PCAP.CD", "AG.LND.ARBL.HA.PC"], ["US", "BR"];
+                    startyear = 1980, endyear = 2008, extra=true, verbose=true)
         if size(dfweb)[1] != 0
             break
         end
@@ -38,13 +39,13 @@ end
 
 # data contains NA which breaks == check
 function rm_na(df)
-    df[map(ismissing, df[:NY_GNP_PCAP_CD]), :NY_GNP_PCAP_CD]=-123456
-    df[map(ismissing, df[:AG_LND_ARBL_HA_PC]), :AG_LND_ARBL_HA_PC]=-123456
+    df[map(ismissing, df[!, :NY_GNP_PCAP_CD]), :NY_GNP_PCAP_CD] = -123456
+    df[map(ismissing, df[!, :AG_LND_ARBL_HA_PC]), :AG_LND_ARBL_HA_PC] = -123456
 end
 
 dfweb = try_download()
 
-@test dfweb[:year] == refdf[:year]
+@test dfweb[!, :year] == refdf[!, :year]
 
 rm_na(dfweb)
 rm_na(refdf)

--- a/test/indicators.jl
+++ b/test/indicators.jl
@@ -15,7 +15,7 @@ indicator_data = Any[ Dict( "total"=>5,"per_page"=>"25000","pages"=>1,"page"=>1 
 
 df_indicator = WorldBankData.parse_indicator(indicator_data)
 
-@test df_indicator[:indicator] == String["12.1_TD.LOSSES", "13.1_INDUSTRY.ENERGY.INTENSITY", "14.1_AGR.ENERGY.INTENSITY", "15.1_OTHER.SECT.ENER.INTENS", "16.1_DECOMP.EFFICIENCY.IND"]
-@test df_indicator[:name] == String["Transmission and distribution losses (%)", "Energy intensity of industrial sector (MJ/\$2005)", "Energy intensity of agricultural sector (MJ/\$2005)", "Energy intensity of other sectors (MJ/\$2005)", "Divisia Decomposition Analysis - Energy Intensity component Index"]
+@test df_indicator[!, :indicator] == ["12.1_TD.LOSSES", "13.1_INDUSTRY.ENERGY.INTENSITY", "14.1_AGR.ENERGY.INTENSITY", "15.1_OTHER.SECT.ENER.INTENS", "16.1_DECOMP.EFFICIENCY.IND"]
+@test df_indicator[!, :name] == ["Transmission and distribution losses (%)", "Energy intensity of industrial sector (MJ/\$2005)", "Energy intensity of agricultural sector (MJ/\$2005)", "Energy intensity of other sectors (MJ/\$2005)", "Divisia Decomposition Analysis - Energy Intensity component Index"]
 
 end

--- a/test/jsonwdi.jl
+++ b/test/jsonwdi.jl
@@ -22,7 +22,7 @@ dfref = DataFrame(iso2c=["US" for _ in range(1, length=8)],
 #│ 5   │ US    │ United States │ 26480.0        │ 1993.0 │
 #│ 6   │ US    │ United States │ 25780.0        │ 1992.0 │
 #│ 7   │ US    │ United States │ 24370.0        │ 1991.0 │
-#│ 8   │ US    │ United States │ 24150.0        │ 1990.0 
+#│ 8   │ US    │ United States │ 24150.0        │ 1990.0
 
 testjson = JSON.parse(testjsonstr)[2]
 

--- a/test/jsonwdi.jl
+++ b/test/jsonwdi.jl
@@ -22,7 +22,7 @@ dfref = DataFrame(iso2c=["US" for _ in range(1, length=8)],
 #│ 5   │ US    │ United States │ 26480.0        │ 1993.0 │
 #│ 6   │ US    │ United States │ 25780.0        │ 1992.0 │
 #│ 7   │ US    │ United States │ 24370.0        │ 1991.0 │
-#│ 8   │ US    │ United States │ 24150.0        │ 1990.0
+#│ 8   │ US    │ United States │ 24150.0        │ 1990.0 
 
 testjson = JSON.parse(testjsonstr)[2]
 

--- a/test/wdi.jl
+++ b/test/wdi.jl
@@ -18,7 +18,7 @@ us_gnp_data = Any[  Dict( "total"=>23,"per_page"=>"25000","pages"=>1,"page"=>1 )
 
 us_gnp = WorldBankData.parse_wdi("NY.GNP.PCAP.CD",us_gnp_data[2],2006,2012)
 
-@test us_gnp[:year] == Float64[2012, 2011, 2010, 2009, 2008, 2007, 2006]
-@test us_gnp[:NY_GNP_PCAP_CD] == Float64[52340, 50650, 48960, 48040, 49350, 48640, 48080]
+@test us_gnp[!, :year] == Float64[2012, 2011, 2010, 2009, 2008, 2007, 2006]
+@test us_gnp[!, :NY_GNP_PCAP_CD] == Float64[52340, 50650, 48960, 48040, 49350, 48640, 48080]
 
 end


### PR DESCRIPTION
So this has turned into a slightly larger PR than I originally planned on. Originally I just wanted to fix an issue with countries that had no data (which led to an error rather than returning an empty DataFrame as in the README. This was fixed by checking explicitly for a `Vector{Nothing}` return type in the `wdi` function. 

I then also noticed that many of the indexing operations on DataFrames still follow deprecated conventions, so fixed those as well. 

Finally, I tidied up the code a bit by making more frequent use of broadcasting in a few places, and generally following the [Invenia BlueStyle guide](https://github.com/invenia/BlueStyle).

I've then also changed the tests & readme to be consistent with the changes made here.